### PR TITLE
fix: suppress exit code output on successful runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,1 @@
-# CLAUDE.md
-
-See [AGENTS.md](./AGENTS.md) for project guidance and instructions.
+AGENTS.md

--- a/cmd/ralph/main.go
+++ b/cmd/ralph/main.go
@@ -170,6 +170,10 @@ func (c *RunCmd) Run() error {
 
 	exitCode := loopRunner.Run(runCtx)
 
+	// Only return an error for non-zero exit codes
+	if exitCode == 0 {
+		return nil
+	}
 	return runExitCode(exitCode)
 }
 

--- a/cmd/ralph/main_test.go
+++ b/cmd/ralph/main_test.go
@@ -129,3 +129,22 @@ func TestRunCmd_GetPrompt(t *testing.T) {
 		})
 	}
 }
+
+func TestRunExitCode_Error(t *testing.T) {
+	tests := []struct {
+		code     int
+		expected string
+	}{
+		{0, "exit code 0"},
+		{1, "exit code 1"},
+		{2, "exit code 2"},
+		{130, "exit code 130"},
+	}
+
+	for _, tt := range tests {
+		code := runExitCode(tt.code)
+		if code.Error() != tt.expected {
+			t.Errorf("runExitCode(%d).Error() = %q, want %q", tt.code, code.Error(), tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Fix issue where successful runs output `error: exit code 0`
- Return `nil` instead of `runExitCode(0)` for successful completions
- Add test coverage for `runExitCode.Error()` method

## Test plan
- [x] Run `go test ./cmd/ralph/...` - all tests pass
- [x] Run `go vet ./...` - no issues
- [ ] Manual test: run ralph loop to completion, verify no exit code message on success

Fixes #18

🤖 Generated with [Claude Code](https://claude.ai/code)