### PR TITLE
feat: add token counts to Complete message

### DIFF
--- a/internal/stream/amp.go
+++ b/internal/stream/amp.go
@@ -55,8 +55,10 @@ type ampResult struct {
 }
 
 type ampUsage struct {
-	InputTokens  int `json:"input_tokens"`
-	OutputTokens int `json:"output_tokens"`
+	InputTokens         int `json:"input_tokens"`
+	OutputTokens        int `json:"output_tokens"`
+	CacheCreationTokens int `json:"cache_creation_input_tokens"`
+	CacheReadTokens     int `json:"cache_read_input_tokens"`
 }
 
 // AmpParser implements Parser for Sourcegraph Amp
@@ -215,6 +217,14 @@ func (p *AmpParser) parseResult(data []byte, now time.Time) ([]*Event, error) {
 		} else {
 			event.Result = msg.Result
 		}
+	}
+
+	// Map usage fields to Event
+	if msg.Usage != nil {
+		event.InputTokens = int64(msg.Usage.InputTokens)
+		event.OutputTokens = int64(msg.Usage.OutputTokens)
+		event.CacheReadTokens = int64(msg.Usage.CacheReadTokens)
+		event.CacheWriteTokens = int64(msg.Usage.CacheCreationTokens)
 	}
 
 	return []*Event{event}, nil

--- a/internal/stream/amp_test.go
+++ b/internal/stream/amp_test.go
@@ -153,6 +153,36 @@ func TestAmpParser_ParseResultSuccess(t *testing.T) {
 	if e.Result != "Task completed successfully" {
 		t.Errorf("Result = %q, want %q", e.Result, "Task completed successfully")
 	}
+	if e.InputTokens != 100 {
+		t.Errorf("InputTokens = %d, want 100", e.InputTokens)
+	}
+	if e.OutputTokens != 50 {
+		t.Errorf("OutputTokens = %d, want 50", e.OutputTokens)
+	}
+}
+
+func TestAmpParser_ParseResultWithCache(t *testing.T) {
+	p := NewAmpParser()
+	data := []byte(`{"type": "result", "subtype": "success", "result": "done", "usage": {"input_tokens": 1000, "output_tokens": 500, "cache_creation_input_tokens": 100, "cache_read_input_tokens": 400}}`)
+
+	events, err := p.Parse(data)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	e := events[0]
+	if e.InputTokens != 1000 {
+		t.Errorf("InputTokens = %d, want 1000", e.InputTokens)
+	}
+	if e.OutputTokens != 500 {
+		t.Errorf("OutputTokens = %d, want 500", e.OutputTokens)
+	}
+	if e.CacheReadTokens != 400 {
+		t.Errorf("CacheReadTokens = %d, want 400", e.CacheReadTokens)
+	}
+	if e.CacheWriteTokens != 100 {
+		t.Errorf("CacheWriteTokens = %d, want 100", e.CacheWriteTokens)
+	}
 }
 
 func TestAmpParser_ParseResultError(t *testing.T) {

--- a/internal/stream/claude_test.go
+++ b/internal/stream/claude_test.go
@@ -407,6 +407,57 @@ func TestClaudeParser_TodoWriteEmpty(t *testing.T) {
 	}
 }
 
+func TestClaudeParser_ResultWithUsage(t *testing.T) {
+	p := NewClaudeParser()
+
+	input := `{"type":"result","result":"done","total_cost_usd":5.7556,"usage":{"input_tokens":1234567,"output_tokens":45000,"cache_creation_input_tokens":50000,"cache_read_input_tokens":800000}}`
+
+	events, err := p.Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+
+	e := events[0]
+	if e.Type != EventResult {
+		t.Errorf("Type = %v, want EventResult", e.Type)
+	}
+	if e.InputTokens != 1234567 {
+		t.Errorf("InputTokens = %d, want 1234567", e.InputTokens)
+	}
+	if e.OutputTokens != 45000 {
+		t.Errorf("OutputTokens = %d, want 45000", e.OutputTokens)
+	}
+	if e.CacheReadTokens != 800000 {
+		t.Errorf("CacheReadTokens = %d, want 800000", e.CacheReadTokens)
+	}
+	if e.CacheWriteTokens != 50000 {
+		t.Errorf("CacheWriteTokens = %d, want 50000", e.CacheWriteTokens)
+	}
+}
+
+func TestClaudeParser_ResultNoUsage(t *testing.T) {
+	p := NewClaudeParser()
+
+	input := `{"type":"result","result":"done","total_cost_usd":0.05}`
+
+	events, err := p.Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	e := events[0]
+	if e.InputTokens != 0 {
+		t.Errorf("InputTokens = %d, want 0", e.InputTokens)
+	}
+	if e.OutputTokens != 0 {
+		t.Errorf("OutputTokens = %d, want 0", e.OutputTokens)
+	}
+}
+
 func TestGetString(t *testing.T) {
 	m := map[string]any{
 		"str":    "value",

--- a/internal/stream/codex.go
+++ b/internal/stream/codex.go
@@ -165,7 +165,9 @@ func (p *CodexParser) parseTurnCompleted(usage *codexUsage, now time.Time) ([]*E
 	}
 
 	if usage != nil {
-		event.Result = fmt.Sprintf("tokens: %d in, %d out", usage.InputTokens, usage.OutputTokens)
+		event.InputTokens = int64(usage.InputTokens)
+		event.OutputTokens = int64(usage.OutputTokens)
+		event.CacheReadTokens = int64(usage.CachedInputTokens)
 	}
 
 	return []*Event{event}, nil

--- a/internal/stream/codex_test.go
+++ b/internal/stream/codex_test.go
@@ -201,8 +201,14 @@ func TestCodexParser_TurnCompleted(t *testing.T) {
 	if !e.IsComplete {
 		t.Error("expected IsComplete = true")
 	}
-	if e.Result != "tokens: 25030 in, 673 out" {
-		t.Errorf("Result = %q, want %q", e.Result, "tokens: 25030 in, 673 out")
+	if e.InputTokens != 25030 {
+		t.Errorf("InputTokens = %d, want 25030", e.InputTokens)
+	}
+	if e.OutputTokens != 673 {
+		t.Errorf("OutputTokens = %d, want 673", e.OutputTokens)
+	}
+	if e.CacheReadTokens != 21760 {
+		t.Errorf("CacheReadTokens = %d, want 21760", e.CacheReadTokens)
 	}
 }
 

--- a/internal/stream/types.go
+++ b/internal/stream/types.go
@@ -50,6 +50,12 @@ type Event struct {
 	Cost      float64 // Cumulative cost at this point
 	CostDelta float64 // Cost of this specific operation
 
+	// Token tracking
+	InputTokens      int64 // Total input tokens
+	OutputTokens     int64 // Output tokens
+	CacheReadTokens  int64 // Tokens read from cache
+	CacheWriteTokens int64 // Tokens written to cache (creation)
+
 	// Todo events
 	TodoItems []TodoItem // Task list items (for EventTodo)
 }


### PR DESCRIPTION
## Summary
- Add token usage statistics (input, output, cache) to the "Complete" message displayed after each agent iteration
- Parse token data from Claude, Codex, and Amp streaming JSON formats
- Display tokens with K/M suffixes for readability

**Before:**
```
✅ Complete (cost: $5.7556, tools: 58, errors: 4, time: 6m7s)
```

**After:**
```
✅ Complete (cost: $5.76, tokens: 1.2M in (850K cached) / 45K out, tools: 58, errors: 4, time: 6m7s)
```

## Test plan
- [x] `make test` passes
- [x] `make lint` passes
- [x] Added tests for Claude parser with usage data
- [x] Added tests for Amp parser with cache fields
- [x] Updated Codex parser test for new behavior
- [x] Added formatter tests for token display and formatting helpers

Closes #22