### PR TITLE
feat: display default review prompts in ralph init

### DIFF
--- a/.ralph/settings.json
+++ b/.ralph/settings.json
@@ -31,6 +31,28 @@
       "failAction": "APPEND"
     }
   ],
+  "reviews": {
+    "reviewAfter": 3,
+    "guardrailRetryLimit": 3,
+    "prompts": [
+      {
+        "name": "detailed",
+        "prompt": "Review your implementation for correctness, edge cases, and error handling."
+      },
+      {
+        "name": "architecture",
+        "prompt": "Step back and review the overall design. Are we solving the right problem the right way?"
+      },
+      {
+        "name": "security",
+        "prompt": "Review for security vulnerabilities: injection, auth, data exposure, and input validation."
+      },
+      {
+        "name": "codeHealth",
+        "prompt": "Review for code health: naming, structure, duplication, and simplicity."
+      }
+    ]
+  },
   "scm": {
     "command": "git",
     "tasks": ["commit"]

--- a/internal/initcmd/initcmd.go
+++ b/internal/initcmd/initcmd.go
@@ -435,12 +435,19 @@ func promptReviewPrompts(reader *bufio.Reader) ([]config.ReviewPrompt, error) {
 		fmt.Printf("    %s:\n      %s\n", p.Name, p.Prompt)
 	}
 
-	useDefaults, err := promptWithDefault(reader, "  Use default review prompts?", "Y")
+	fmt.Print("  Use default review prompts? [Y/n]: ")
+	line, err := reader.ReadString('\n')
 	if err != nil {
+		if err == io.EOF {
+			fmt.Println("\nAborted.")
+			exitFunc(130)
+			return nil, nil
+		}
 		return nil, err
 	}
+	useDefaults := strings.TrimSpace(line)
 
-	if strings.ToLower(useDefaults) == "y" {
+	if useDefaults == "" || strings.ToLower(useDefaults) == "y" {
 		return config.DefaultReviewPrompts(), nil
 	}
 

--- a/internal/initcmd/initcmd.go
+++ b/internal/initcmd/initcmd.go
@@ -429,8 +429,13 @@ func promptGuardrailRetryLimit(reader *bufio.Reader) (int, error) {
 }
 
 func promptReviewPrompts(reader *bufio.Reader) ([]config.ReviewPrompt, error) {
-	useDefaults, err := promptWithDefault(reader,
-		"  Use default review prompts (detailed, architecture, security, codeHealth)?", "Y")
+	// Show default prompts
+	fmt.Println("  Default review prompts:")
+	for _, p := range config.DefaultReviewPrompts() {
+		fmt.Printf("    %s: %s\n", p.Name, p.Prompt)
+	}
+
+	useDefaults, err := promptWithDefault(reader, "  Use default review prompts?", "Y")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/initcmd/initcmd.go
+++ b/internal/initcmd/initcmd.go
@@ -89,6 +89,11 @@ func Run() error {
 		return err
 	}
 
+	reviews, err := promptReviews(reader)
+	if err != nil {
+		return err
+	}
+
 	scm, err := promptSCM(reader)
 	if err != nil {
 		return err
@@ -102,6 +107,9 @@ func Run() error {
 	settings.CompletionResponse = completionResponse
 	settings.IncludeIterationCountInPrompt = includeIterationCount
 	settings.Guardrails = guardrails
+	if reviews != nil {
+		settings.Reviews = reviews
+	}
 	if scm != nil {
 		settings.SCM = scm
 	}
@@ -348,6 +356,116 @@ func promptSCM(reader *bufio.Reader) (*config.SCMConfig, error) {
 		Command: scmCommand,
 		Tasks:   tasks,
 	}, nil
+}
+
+func promptReviews(reader *bufio.Reader) (*config.ReviewsConfig, error) {
+	configureReviews, err := prompt(reader, "Configure review cycles? (y/N): ")
+	if err != nil {
+		return nil, err
+	}
+
+	if strings.ToLower(configureReviews) != "y" {
+		return nil, nil
+	}
+
+	reviewAfter, err := promptReviewAfter(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	retryLimit, err := promptGuardrailRetryLimit(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	prompts, err := promptReviewPrompts(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	return &config.ReviewsConfig{
+		ReviewAfter:         reviewAfter,
+		GuardrailRetryLimit: retryLimit,
+		Prompts:             prompts,
+	}, nil
+}
+
+func promptReviewAfter(reader *bufio.Reader) (int, error) {
+	for {
+		input, err := promptWithDefault(reader, "  Review after iterations", "5")
+		if err != nil {
+			return 0, err
+		}
+		parsed, parseErr := strconv.Atoi(input)
+		if parseErr != nil {
+			fmt.Fprintln(os.Stderr, "  Please enter a valid number")
+			continue
+		}
+		if parsed < 0 {
+			fmt.Fprintln(os.Stderr, "  Must be 0 or greater")
+			continue
+		}
+		return parsed, nil
+	}
+}
+
+func promptGuardrailRetryLimit(reader *bufio.Reader) (int, error) {
+	for {
+		input, err := promptWithDefault(reader, "  Guardrail retry limit", "3")
+		if err != nil {
+			return 0, err
+		}
+		parsed, parseErr := strconv.Atoi(input)
+		if parseErr != nil {
+			fmt.Fprintln(os.Stderr, "  Please enter a valid number")
+			continue
+		}
+		if parsed < 0 {
+			fmt.Fprintln(os.Stderr, "  Must be 0 or greater")
+			continue
+		}
+		return parsed, nil
+	}
+}
+
+func promptReviewPrompts(reader *bufio.Reader) ([]config.ReviewPrompt, error) {
+	useDefaults, err := promptWithDefault(reader,
+		"  Use default review prompts (detailed, architecture, security, codeHealth)?", "Y")
+	if err != nil {
+		return nil, err
+	}
+
+	normalized := strings.ToLower(strings.TrimSpace(useDefaults))
+	if normalized == "y" || normalized == "yes" || normalized == "" {
+		return config.DefaultReviewPrompts(), nil
+	}
+
+	// Custom prompt loop
+	var prompts []config.ReviewPrompt
+	for {
+		nameInput, err := prompt(reader, "  Add review prompt (leave blank to finish):\n    Name: ")
+		if err != nil {
+			return nil, err
+		}
+		if nameInput == "" {
+			break
+		}
+
+		promptInput, err := prompt(reader, "    Prompt: ")
+		if err != nil {
+			return nil, err
+		}
+		if promptInput == "" {
+			break
+		}
+
+		prompts = append(prompts, config.ReviewPrompt{
+			Name:   nameInput,
+			Prompt: promptInput,
+		})
+	}
+
+	return prompts, nil
 }
 
 func writeSettings(settings config.Settings) error {

--- a/internal/initcmd/initcmd.go
+++ b/internal/initcmd/initcmd.go
@@ -429,10 +429,10 @@ func promptGuardrailRetryLimit(reader *bufio.Reader) (int, error) {
 }
 
 func promptReviewPrompts(reader *bufio.Reader) ([]config.ReviewPrompt, error) {
-	// Show default prompts
+	// Show default prompts with multi-line formatting for readability
 	fmt.Println("  Default review prompts:")
 	for _, p := range config.DefaultReviewPrompts() {
-		fmt.Printf("    %s: %s\n", p.Name, p.Prompt)
+		fmt.Printf("    %s:\n      %s\n", p.Name, p.Prompt)
 	}
 
 	useDefaults, err := promptWithDefault(reader, "  Use default review prompts?", "Y")
@@ -440,8 +440,7 @@ func promptReviewPrompts(reader *bufio.Reader) ([]config.ReviewPrompt, error) {
 		return nil, err
 	}
 
-	normalized := strings.ToLower(strings.TrimSpace(useDefaults))
-	if normalized == "y" || normalized == "yes" || normalized == "" {
+	if strings.ToLower(useDefaults) == "y" {
 		return config.DefaultReviewPrompts(), nil
 	}
 

--- a/internal/initcmd/initcmd_test.go
+++ b/internal/initcmd/initcmd_test.go
@@ -1389,21 +1389,21 @@ func TestRun_CustomPrompts_EmptyPromptExitsLoop(t *testing.T) {
 		defer mockTTY(true)()
 
 		input := strings.Join([]string{
-			"claude",                   // agent command
-			"",                         // no flags
-			"",                         // default iterations
-			"",                         // default completion
-			"",                         // default include iteration count
-			"",                         // no guardrails
-			"y",                        // configure reviews
-			"",                         // default review after
-			"",                         // default retry limit
-			"n",                        // custom prompts
-			"firstReview",              // first prompt name
-			"Check for errors.",        // first prompt text
-			"secondReview",             // second prompt name (will exit on empty prompt)
-			"",                         // empty prompt - exits loop
-			"N",                        // no SCM
+			"claude",            // agent command
+			"",                  // no flags
+			"",                  // default iterations
+			"",                  // default completion
+			"",                  // default include iteration count
+			"",                  // no guardrails
+			"y",                 // configure reviews
+			"",                  // default review after
+			"",                  // default retry limit
+			"n",                 // custom prompts
+			"firstReview",       // first prompt name
+			"Check for errors.", // first prompt text
+			"secondReview",      // second prompt name (will exit on empty prompt)
+			"",                  // empty prompt - exits loop
+			"N",                 // no SCM
 		}, "\n") + "\n"
 
 		withStdin(t, input, func() {

--- a/internal/initcmd/initcmd_test.go
+++ b/internal/initcmd/initcmd_test.go
@@ -89,7 +89,7 @@ func TestRun_HappyPath(t *testing.T) {
 		defer mockTTY(true)()
 
 		// Input: agent command, flags, max iterations (default), completion (default),
-		// iteration count (default), one guardrail with hint, exit guardrail loop, decline SCM
+		// iteration count (default), one guardrail with hint, exit guardrail loop, decline reviews, decline SCM
 		input := strings.Join([]string{
 			"claude",                // agent command
 			"--model,opus",          // agent flags (comma-separated)
@@ -100,6 +100,7 @@ func TestRun_HappyPath(t *testing.T) {
 			"APPEND",                // fail action
 			"Fix lint errors only.", // hint
 			"",                      // exit guardrail loop
+			"N",                     // don't configure reviews
 			"N",                     // don't configure SCM
 		}, "\n") + "\n"
 
@@ -175,6 +176,7 @@ func TestRun_WithSCM(t *testing.T) {
 			"",       // default completion
 			"",       // default include iteration count
 			"",       // no guardrails
+			"N",      // no reviews
 			"y",      // configure SCM
 			"git",    // SCM command
 			"commit", // SCM tasks
@@ -297,6 +299,7 @@ func TestRun_ExistingSettings_AcceptOverwrite(t *testing.T) {
 			"",          // default completion
 			"",          // default include iteration count
 			"",          // no guardrails
+			"N",         // no reviews
 			"N",         // no SCM
 		}, "\n") + "\n"
 
@@ -427,6 +430,7 @@ func TestRun_MalformedExistingSettings(t *testing.T) {
 			"",          // default completion
 			"",          // default include iteration count
 			"",          // no guardrails
+			"N",         // no reviews
 			"N",         // no SCM
 		}, "\n") + "\n"
 
@@ -484,6 +488,7 @@ func TestRun_EmptyAgentCommand_Reprompt(t *testing.T) {
 			"",       // default completion
 			"",       // default include iteration count
 			"",       // no guardrails
+			"N",      // no reviews
 			"N",      // no SCM
 		}, "\n") + "\n"
 
@@ -543,6 +548,7 @@ func TestRun_InvalidFailAction_Reprompt(t *testing.T) {
 			"APPEND",    // valid action
 			"",          // hint (empty)
 			"",          // exit guardrail loop
+			"N",         // no reviews
 			"N",         // no SCM
 		}, "\n") + "\n"
 
@@ -599,6 +605,7 @@ func TestRun_FailActionCaseNormalization(t *testing.T) {
 			"append",    // lowercase - should be normalized
 			"",          // hint (empty)
 			"",          // exit guardrail loop
+			"N",         // no reviews
 			"N",         // no SCM
 		}, "\n") + "\n"
 
@@ -644,6 +651,7 @@ func TestRun_GuardrailLoopExit(t *testing.T) {
 			"PREPEND",
 			"",  // hint for second guardrail (empty)
 			"",  // exit loop (empty command)
+			"N", // no reviews
 			"N", // no SCM
 		}, "\n") + "\n"
 
@@ -683,6 +691,7 @@ func TestRun_SCMDeclined(t *testing.T) {
 			"",       // default completion
 			"",       // default include iteration count
 			"",       // no guardrails
+			"N",      // no reviews
 			"N",      // decline SCM
 		}, "\n") + "\n"
 
@@ -812,6 +821,7 @@ func TestRun_WhitespaceTrimming(t *testing.T) {
 			"",                        // default completion
 			"",                        // default include iteration count
 			"",                        // no guardrails
+			"N",                       // no reviews
 			"y",                       // configure SCM
 			"git",                     // SCM command
 			"  commit  ,  push  ,  ",  // tasks with whitespace
@@ -883,6 +893,7 @@ func TestRun_InvalidMaxIterations_Reprompt(t *testing.T) {
 			"",       // default completion
 			"",       // default include iteration count
 			"",       // no guardrails
+			"N",      // no reviews
 			"N",      // no SCM
 		}, "\n") + "\n"
 
@@ -937,6 +948,7 @@ func TestRun_ZeroGuardrails(t *testing.T) {
 			"",       // default completion
 			"",       // default include iteration count
 			"",       // immediately exit guardrails (no guardrails added)
+			"N",      // no reviews
 			"N",      // no SCM
 		}, "\n") + "\n"
 
@@ -976,6 +988,7 @@ func TestRun_CustomCompletionResponse(t *testing.T) {
 			"FINISHED", // custom completion response
 			"",         // default include iteration count
 			"",         // no guardrails
+			"N",        // no reviews
 			"N",        // no SCM
 		}, "\n") + "\n"
 
@@ -1015,6 +1028,7 @@ func TestRun_IncludeIterationCountPrompt(t *testing.T) {
 			"",       // default completion
 			"y",      // include iteration count
 			"",       // no guardrails
+			"N",      // no reviews
 			"N",      // no SCM
 		}, "\n") + "\n"
 
@@ -1037,6 +1051,367 @@ func TestRun_IncludeIterationCountPrompt(t *testing.T) {
 
 		if !settings.IncludeIterationCountInPrompt {
 			t.Errorf("includeIterationCountInPrompt = %v, want true", settings.IncludeIterationCountInPrompt)
+		}
+	})
+}
+
+func TestRun_WithReviews_DefaultPrompts(t *testing.T) {
+	withTempDir(t, func(dir string) {
+		captureExit()
+		defer restoreExit()
+		defer mockTTY(true)()
+
+		input := strings.Join([]string{
+			"claude", // agent command
+			"",       // no flags
+			"",       // default iterations
+			"",       // default completion
+			"",       // default include iteration count
+			"",       // no guardrails
+			"y",      // configure reviews
+			"",       // default review after (5)
+			"",       // default guardrail retry limit (3)
+			"",       // use default prompts (Y)
+			"N",      // no SCM
+		}, "\n") + "\n"
+
+		withStdin(t, input, func() {
+			err := Run()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+
+		data, err := os.ReadFile(".ralph/settings.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var settings config.Settings
+		if err := json.Unmarshal(data, &settings); err != nil {
+			t.Fatal(err)
+		}
+
+		if settings.Reviews == nil {
+			t.Fatal("reviews should not be nil")
+		}
+		if settings.Reviews.ReviewAfter != 5 {
+			t.Errorf("reviews.reviewAfter = %d, want 5", settings.Reviews.ReviewAfter)
+		}
+		if settings.Reviews.GuardrailRetryLimit != 3 {
+			t.Errorf("reviews.guardrailRetryLimit = %d, want 3", settings.Reviews.GuardrailRetryLimit)
+		}
+		if len(settings.Reviews.Prompts) != 4 {
+			t.Errorf("reviews.prompts length = %d, want 4 default prompts", len(settings.Reviews.Prompts))
+		}
+
+		// Verify default prompts are present
+		expectedNames := []string{"detailed", "architecture", "security", "codeHealth"}
+		for i, name := range expectedNames {
+			if settings.Reviews.Prompts[i].Name != name {
+				t.Errorf("reviews.prompts[%d].name = %q, want %q", i, settings.Reviews.Prompts[i].Name, name)
+			}
+		}
+	})
+}
+
+func TestRun_WithReviews_CustomPrompts(t *testing.T) {
+	withTempDir(t, func(dir string) {
+		captureExit()
+		defer restoreExit()
+		defer mockTTY(true)()
+
+		input := strings.Join([]string{
+			"claude",                  // agent command
+			"",                        // no flags
+			"",                        // default iterations
+			"",                        // default completion
+			"",                        // default include iteration count
+			"",                        // no guardrails
+			"y",                       // configure reviews
+			"10",                      // custom review after
+			"2",                       // custom guardrail retry limit
+			"n",                       // don't use defaults
+			"correctness",             // first prompt name
+			"Check for logic errors.", // first prompt text
+			"tests",                   // second prompt name
+			"Review test coverage.",   // second prompt text
+			"",                        // exit prompt loop (blank name)
+			"N",                       // no SCM
+		}, "\n") + "\n"
+
+		withStdin(t, input, func() {
+			err := Run()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+
+		data, err := os.ReadFile(".ralph/settings.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var settings config.Settings
+		if err := json.Unmarshal(data, &settings); err != nil {
+			t.Fatal(err)
+		}
+
+		if settings.Reviews == nil {
+			t.Fatal("reviews should not be nil")
+		}
+		if settings.Reviews.ReviewAfter != 10 {
+			t.Errorf("reviews.reviewAfter = %d, want 10", settings.Reviews.ReviewAfter)
+		}
+		if settings.Reviews.GuardrailRetryLimit != 2 {
+			t.Errorf("reviews.guardrailRetryLimit = %d, want 2", settings.Reviews.GuardrailRetryLimit)
+		}
+		if len(settings.Reviews.Prompts) != 2 {
+			t.Fatalf("reviews.prompts length = %d, want 2", len(settings.Reviews.Prompts))
+		}
+
+		if settings.Reviews.Prompts[0].Name != "correctness" {
+			t.Errorf("prompts[0].name = %q, want %q", settings.Reviews.Prompts[0].Name, "correctness")
+		}
+		if settings.Reviews.Prompts[0].Prompt != "Check for logic errors." {
+			t.Errorf("prompts[0].prompt = %q, want %q", settings.Reviews.Prompts[0].Prompt, "Check for logic errors.")
+		}
+		if settings.Reviews.Prompts[1].Name != "tests" {
+			t.Errorf("prompts[1].name = %q, want %q", settings.Reviews.Prompts[1].Name, "tests")
+		}
+	})
+}
+
+func TestRun_ReviewsDeclined(t *testing.T) {
+	withTempDir(t, func(dir string) {
+		captureExit()
+		defer restoreExit()
+		defer mockTTY(true)()
+
+		input := strings.Join([]string{
+			"claude", // agent command
+			"",       // no flags
+			"",       // default iterations
+			"",       // default completion
+			"",       // default include iteration count
+			"",       // no guardrails
+			"N",      // decline reviews
+			"N",      // no SCM
+		}, "\n") + "\n"
+
+		withStdin(t, input, func() {
+			err := Run()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+
+		data, err := os.ReadFile(".ralph/settings.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var settings config.Settings
+		if err := json.Unmarshal(data, &settings); err != nil {
+			t.Fatal(err)
+		}
+
+		if settings.Reviews != nil {
+			t.Error("reviews should be nil when declined")
+		}
+	})
+}
+
+func TestRun_ReviewAfter_InvalidInput_Reprompt(t *testing.T) {
+	withTempDir(t, func(dir string) {
+		captureExit()
+		defer restoreExit()
+		defer mockTTY(true)()
+
+		// Capture stderr
+		oldStderr := os.Stderr
+		r, w, _ := os.Pipe()
+		os.Stderr = w
+
+		input := strings.Join([]string{
+			"claude", // agent command
+			"",       // no flags
+			"",       // default iterations
+			"",       // default completion
+			"",       // default include iteration count
+			"",       // no guardrails
+			"y",      // configure reviews
+			"abc",    // invalid - not a number
+			"-5",     // invalid - negative
+			"7",      // valid
+			"",       // default retry limit
+			"",       // use default prompts
+			"N",      // no SCM
+		}, "\n") + "\n"
+
+		withStdin(t, input, func() {
+			err := Run()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+
+		w.Close()
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		os.Stderr = oldStderr
+		stderrOutput := buf.String()
+
+		// Verify error messages
+		if !strings.Contains(stderrOutput, "valid number") {
+			t.Errorf("expected 'valid number' in stderr, got: %s", stderrOutput)
+		}
+		if !strings.Contains(stderrOutput, "0 or greater") {
+			t.Errorf("expected '0 or greater' in stderr, got: %s", stderrOutput)
+		}
+
+		// Verify final value
+		data, err := os.ReadFile(".ralph/settings.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var settings config.Settings
+		if err := json.Unmarshal(data, &settings); err != nil {
+			t.Fatal(err)
+		}
+
+		if settings.Reviews == nil {
+			t.Fatal("reviews should not be nil")
+		}
+		if settings.Reviews.ReviewAfter != 7 {
+			t.Errorf("reviews.reviewAfter = %d, want 7", settings.Reviews.ReviewAfter)
+		}
+	})
+}
+
+func TestRun_GuardrailRetryLimit_InvalidInput_Reprompt(t *testing.T) {
+	withTempDir(t, func(dir string) {
+		captureExit()
+		defer restoreExit()
+		defer mockTTY(true)()
+
+		// Capture stderr
+		oldStderr := os.Stderr
+		r, w, _ := os.Pipe()
+		os.Stderr = w
+
+		input := strings.Join([]string{
+			"claude", // agent command
+			"",       // no flags
+			"",       // default iterations
+			"",       // default completion
+			"",       // default include iteration count
+			"",       // no guardrails
+			"y",      // configure reviews
+			"",       // default review after
+			"xyz",    // invalid - not a number
+			"-1",     // invalid - negative
+			"5",      // valid
+			"",       // use default prompts
+			"N",      // no SCM
+		}, "\n") + "\n"
+
+		withStdin(t, input, func() {
+			err := Run()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+
+		w.Close()
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		os.Stderr = oldStderr
+		stderrOutput := buf.String()
+
+		// Verify error messages
+		if !strings.Contains(stderrOutput, "valid number") {
+			t.Errorf("expected 'valid number' in stderr, got: %s", stderrOutput)
+		}
+		if !strings.Contains(stderrOutput, "0 or greater") {
+			t.Errorf("expected '0 or greater' in stderr, got: %s", stderrOutput)
+		}
+
+		// Verify final value
+		data, err := os.ReadFile(".ralph/settings.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var settings config.Settings
+		if err := json.Unmarshal(data, &settings); err != nil {
+			t.Fatal(err)
+		}
+
+		if settings.Reviews == nil {
+			t.Fatal("reviews should not be nil")
+		}
+		if settings.Reviews.GuardrailRetryLimit != 5 {
+			t.Errorf("reviews.guardrailRetryLimit = %d, want 5", settings.Reviews.GuardrailRetryLimit)
+		}
+	})
+}
+
+func TestRun_CustomPrompts_EmptyPromptExitsLoop(t *testing.T) {
+	withTempDir(t, func(dir string) {
+		captureExit()
+		defer restoreExit()
+		defer mockTTY(true)()
+
+		input := strings.Join([]string{
+			"claude",                   // agent command
+			"",                         // no flags
+			"",                         // default iterations
+			"",                         // default completion
+			"",                         // default include iteration count
+			"",                         // no guardrails
+			"y",                        // configure reviews
+			"",                         // default review after
+			"",                         // default retry limit
+			"n",                        // custom prompts
+			"firstReview",              // first prompt name
+			"Check for errors.",        // first prompt text
+			"secondReview",             // second prompt name (will exit on empty prompt)
+			"",                         // empty prompt - exits loop
+			"N",                        // no SCM
+		}, "\n") + "\n"
+
+		withStdin(t, input, func() {
+			err := Run()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+
+		// Verify final settings
+		data, err := os.ReadFile(".ralph/settings.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var settings config.Settings
+		if err := json.Unmarshal(data, &settings); err != nil {
+			t.Fatal(err)
+		}
+
+		if settings.Reviews == nil {
+			t.Fatal("reviews should not be nil")
+		}
+		// Only the first prompt should be saved (second was abandoned)
+		if len(settings.Reviews.Prompts) != 1 {
+			t.Fatalf("expected 1 prompt, got %d", len(settings.Reviews.Prompts))
+		}
+		if settings.Reviews.Prompts[0].Name != "firstReview" {
+			t.Errorf("prompt name = %q, want %q", settings.Reviews.Prompts[0].Name, "firstReview")
+		}
+		if settings.Reviews.Prompts[0].Prompt != "Check for errors." {
+			t.Errorf("prompt = %q, want %q", settings.Reviews.Prompts[0].Prompt, "Check for errors.")
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Show the full text of each default review prompt before asking the user whether to use them
- Improves visibility into what each prompt (detailed, architecture, security, codeHealth) actually does
- Updated test to verify prompts are displayed in output

## Test plan
- [x] `make test` - all tests pass
- [x] `make lint` - no lint errors
- [ ] Manual test: `go run ./cmd/ralph init` and verify prompts display correctly when configuring reviews